### PR TITLE
Fix hard-coded name lengths

### DIFF
--- a/src/intro/file_select_menu_loop.asm
+++ b/src/intro/file_select_menu_loop.asm
@@ -250,7 +250,7 @@ FILE_MENU_LOOP: ;$C1F805
 	STA $04
 	LDY $04
 	LDX #.LOWORD(GAME_STATE) + game_state::favourite_thing + 4 ; part after 'PSI ' prefix
-	LDA #.SIZEOF(game_state::favourite_thing)
+	LDA #.SIZEOF(game_state::favourite_thing) - 6
 	JSR NAME_A_CHARACTER
 	CMP #$0000
 	BEQ @UNKNOWN29

--- a/src/intro/file_select_menu_loop.asm
+++ b/src/intro/file_select_menu_loop.asm
@@ -186,7 +186,7 @@ FILE_MENU_LOOP: ;$C1F805
 	STA $04
 	LDY $04
 	LDX #.LOWORD(GAME_STATE) + game_state::pet_name
-	LDA #$0006
+	LDA #.SIZEOF(game_state::pet_name)
 	JSR NAME_A_CHARACTER
 	CMP #$0000
 	BEQ @UNKNOWN25
@@ -218,7 +218,7 @@ FILE_MENU_LOOP: ;$C1F805
 	STA $04
 	LDY $04
 	LDX #.LOWORD(GAME_STATE) + game_state::favourite_food
-	LDA #$0006
+	LDA #.SIZEOF(game_state::favourite_food)
 	JSR NAME_A_CHARACTER
 	CMP #$0000
 	BEQ @UNKNOWN27
@@ -250,7 +250,7 @@ FILE_MENU_LOOP: ;$C1F805
 	STA $04
 	LDY $04
 	LDX #.LOWORD(GAME_STATE) + game_state::favourite_thing + 4 ; part after 'PSI ' prefix
-	LDA #$0006
+	LDA #.SIZEOF(game_state::favourite_thing)
 	JSR NAME_A_CHARACTER
 	CMP #$0000
 	BEQ @UNKNOWN29


### PR DESCRIPTION
Because the lengths of these are always `0006` (as opposed to character names), Nintendo's compiler probably optimized them out