### PR TITLE
Don't include USA deps, except when building a USA ROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ include $(wildcard $(JPSRCDIR)/*.dep)
 else ifeq ($(MAKECMDGOALS),proto19950327)
 CA65FLAGS += -D USA -D PROTOTYPE19950327
 include $(wildcard $(USPROTOSRCDIR)/*.dep)
-else
+else ifneq ($(if $(MAKECMDGOALS),$(filter all earthbound,$(MAKECMDGOALS)),itsthedefaulttarget),)
+# The above ifneq condition will trigger if either
+# - MAKECMDGOALS is empty (there is no specified make target, so build the default target), or
+# - the target is all/earthbound
 CA65FLAGS += -D USA
 include $(wildcard $(USSRCDIR)/*.dep)
 endif


### PR DESCRIPTION
Minimal version of the bug fix from #29.

Previously, .deps would be `include`d even for unrelated targets like `make extract`. This can create a chicken-and-egg problem if it triggers a build error: running `make extract` tries to update any existing .dep files, which tries to build the code, which may fail due to a missing incbin (or even another assembly error that has nothing to do with dumping assets).

With this change, nothing is `include`d if none of the main targets (all/earthbound/proto19950327/mother2) is being built.